### PR TITLE
Fixed issue with read after write

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -145,6 +145,9 @@ int main() {
     
         // Store number
         fprintf(f, "    %d\n", number);
+
+        // Flush between write and read on same file
+        fflush(f);
     }
     printf("\rIncrementing numbers (%d/%d)... OK\n", 10, 10);
 


### PR DESCRIPTION
per the open group documentation ([here](http://pubs.opengroup.org/onlinepubs/000095399/functions/fopen.html)):

> When a file is opened with update mode ('+' as the second or third character in the mode argument), both input and output may be performed on the associated stream. However, the application shall ensure that output is not directly followed by input without an intervening call to fflush() or to a file positioning function (fseek(), fsetpos(), or rewind()).

Unfortunately, the example has an ftell between a read and a write, which will cause the data to be flushed on GCG + IAR, but not on ARMCC.

should resolve https://github.com/ARMmbed/mbed-os-example-filesystem/issues/16
cc @kegilbert, @cmonr 