### PR TITLE
Mbed os 5.10.0 oob

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,7 @@
 
 env:
   matrix:
-    - TARGET=K82F
-    - TARGET=NRF52840_DK
-    - TARGET=K64F
-    - TARGET=UBLOX_EVK_ODIN_W2
-    - TARGET=NUCLEO_F429ZI
+    
   global:
     - >
       STATUS=$'curl -so/dev/null --user $MBED_BOT --request POST
@@ -54,21 +50,12 @@ install:
 
 script:
   # Check that example compiles with littlefs + spif
-  - mbed compile -t GCC_ARM -m $TARGET -j0
-
-  # Check that example compiles with littlefs + dataflash
-  - sed -i 's/SPIFBlockDevice bd/DataFlashBlockDevice bd/g' main.cpp
-  - sed -i 's/MBED_CONF_SPIF_DRIVER/MBED_CONF_DATAFLASH/g' main.cpp
-  - mbed compile -t GCC_ARM -m $TARGET -j0
+  - mbed compile -t GCC_ARM -m K82F -j0
 
   # Check that example compiles with fatfs + sd
+  - sed -i 's/SPIFBlockDevice bd/SDBlockDevice bd/g' main.cpp
+  - sed -i 's/MBED_CONF_SPIF_DRIVER/MBED_CONF_SD/g' main.cpp
   - sed -i 's/LittleFileSystem fs/FATFileSystem fs/g' main.cpp
-  - sed -i 's/DataFlashBlockDevice bd/SDBlockDevice bd/g' main.cpp
-  - sed -i 's/MBED_CONF_DATAFLASH/MBED_CONF_SD/g' main.cpp
-  - mbed compile -t GCC_ARM -m $TARGET -j0
+  - mbed compile -t GCC_ARM -m K64F -j0
 
-  # Check that example compiles with fatfs + heap
-  - sed -i 's/SDBlockDevice bd(/HeapBlockDevice bd(1024*512, 512);/g' main.cpp
-  - sed -i '/MBED_CONF_SD/d' main.cpp
-  - mbed compile -t GCC_ARM -m $TARGET -j0
 

--- a/README.md
+++ b/README.md
@@ -261,6 +261,32 @@ pins in `<driver>/mbed_lib.json` are correct. For example, to change the pins fo
          ...
      }
 ```
+The pins macros define above can be override at the application configuration file using the driver prefix before the parameter name.
+```
+   "target_overrides": {
+         ...
+         "NUCLEO_F429ZI": {
+             "spif-driver.SPI_MOSI": "PC_12",
+             "spif-driver.SPI_MISO": "PC_11",
+             "spif-driver.SPI_CLK":  "PC_10",
+             "spif-driver.SPI_CS":   "PA_15"
+         },
+         ...
+     }
+```
+or 
+```
+   "target_overrides": {
+         ...
+         "NUCLEO_F429ZI": {
+             "sd.SPI_MOSI": "PC_12",
+             "sd.SPI_MISO": "PC_11",
+             "sd.SPI_CLK":  "PC_10",
+             "sd.SPI_CS":   "PA_15"
+         },
+         ...
+     }
+```
 
 Mbed OS has several options for the block device:
 
@@ -277,12 +303,12 @@ Mbed OS has several options for the block device:
           MBED_CONF_SPIF_DRIVER_SPI_CS);
   ```
 
-  Starting mbed-os 5.10 the SPIFBlockDevice is a component under mbed-os. In order to add a component to the application use the following `target_overrides` configuration:
+  Starting mbed-os 5.10 the SPIFBlockDevice is a component under mbed-os. In order to add a component to the application use the following `target_overrides` configuration at the application configuration file:
 ```
   "target_overrides": {
          ...
          "NUCLEO_F429ZI": {
-             "components_add": ["SPIF"],
+             "target.components_add": ["SPIF"],
              ...
          },
          ...
@@ -305,12 +331,12 @@ Mbed OS has several options for the block device:
           MBED_CONF_DATAFLASH_SPI_CS);
   ```
 
-  Starting mbed-os 5.10 the DataFlashBlockDevice is a component under mbed-os. In order to add a component to the application use the following `target_overrides` configuration:
+  Starting mbed-os 5.10 the DataFlashBlockDevice is a component under mbed-os. In order to add a component to the application use the following `target_overrides` configuration at the application configuration file:
 ```
   "target_overrides": {
          ...
          "NUCLEO_F429ZI": {
-             "components_add": ["DATAFLASH"],
+             "target.components_add": ["DATAFLASH"],
              ...
          },
          ...
@@ -331,12 +357,12 @@ Mbed OS has several options for the block device:
           MBED_CONF_SD_SPI_CS);
   ```
 
-  Starting mbed-os 5.10 the SDBlockDevice is a component under mbed-os. In order to add a component to the application use the following `target_overrides` configuration:
+  Starting mbed-os 5.10 the SDBlockDevice is a component under mbed-os. In order to add a component to the application use the following `target_overrides` configuration at the application configuration file:
 ```
   "target_overrides": {
          ...
          "NUCLEO_F429ZI": {
-             "components_add": ["SD"],
+             "target.components_add": ["SD"],
              ...
          },
          ...

--- a/README.md
+++ b/README.md
@@ -277,6 +277,18 @@ Mbed OS has several options for the block device:
           MBED_CONF_SPIF_DRIVER_SPI_CS);
   ```
 
+  Starting mbed-os 5.10 the SPIFBlockDevice is a component under mbed-os. In order to add a component to the application use the following `target_overrides` configuration:
+```
+  "target_overrides": {
+         ...
+         "NUCLEO_F429ZI": {
+             "components_add": ["SPIF"],
+             ...
+         },
+         ...
+  }
+```
+
 - **DataFlashBlockDevice** - Block device driver for NOR-based SPI flash devices
   that support the DataFlash protocol, such as the Adesto AT45DB series of
   devices. DataFlash is a memory protocol that combines flash with SRAM buffers
@@ -293,6 +305,18 @@ Mbed OS has several options for the block device:
           MBED_CONF_DATAFLASH_SPI_CS);
   ```
 
+  Starting mbed-os 5.10 the DataFlashBlockDevice is a component under mbed-os. In order to add a component to the application use the following `target_overrides` configuration:
+```
+  "target_overrides": {
+         ...
+         "NUCLEO_F429ZI": {
+             "components_add": ["DATAFLASH"],
+             ...
+         },
+         ...
+  }
+```
+
 - **SDBlockDevice** - Block device driver for SD cards and eMMC memory chips. SD
   cards or eMMC chips offer a full FTL layer on top of NAND flash. This makes the
   storage well-suited for systems that require a about 1GB of memory.
@@ -306,6 +330,18 @@ Mbed OS has several options for the block device:
           MBED_CONF_SD_SPI_CLK,
           MBED_CONF_SD_SPI_CS);
   ```
+
+  Starting mbed-os 5.10 the SDBlockDevice is a component under mbed-os. In order to add a component to the application use the following `target_overrides` configuration:
+```
+  "target_overrides": {
+         ...
+         "NUCLEO_F429ZI": {
+             "components_add": ["SD"],
+             ...
+         },
+         ...
+  }
+```
 
 - [**HeapBlockDevice**](https://os.mbed.com/docs/v5.6/reference/heapblockdevice.html) -
   Block device that simulates storage in RAM using the heap. Do not use the heap

--- a/dataflash-driver.lib
+++ b/dataflash-driver.lib
@@ -1,1 +1,0 @@
-https://github.com/ARMmbed/dataflash-driver/#eb1316530ffe0c2ba934b5aee158a0a08ff0388b

--- a/main.cpp
+++ b/main.cpp
@@ -18,9 +18,18 @@
 #include <errno.h>
 
 // Block devices
+#if COMPONENT_SPIF
 #include "SPIFBlockDevice.h"
+#endif
+
+#if COMPONENT_DATAFLASH
 #include "DataFlashBlockDevice.h"
+#endif 
+
+#if COMPONENT_SD
 #include "SDBlockDevice.h"
+#endif 
+
 #include "HeapBlockDevice.h"
 
 // File systems

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#0fdfcf7350896a9c0b57c4a18237677abfe25f1a
+https://github.com/ARMmbed/mbed-os/#3fb5781af180c32a6062f050d59cdf93654b3e9f

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#3fb5781af180c32a6062f050d59cdf93654b3e9f
+https://github.com/ARMmbed/mbed-os/#610e35ddc6d59f153173c1e7b2748cf96d6c9bcd

--- a/sd-driver.lib
+++ b/sd-driver.lib
@@ -1,1 +1,0 @@
-https://github.com/ARMmbed/sd-driver/#c16fa2bf36b87e862f81e0b30dbddca1460e1084

--- a/spif-driver.lib
+++ b/spif-driver.lib
@@ -1,1 +1,0 @@
-https://github.com/ARMmbed/spif-driver/#e5e6616914a23fb11a5ae8b5c9cbfb8a600c64b2


### PR DESCRIPTION
This PR is to update mbed-os-example-filesystem to work with the mbed-os 5.10.0