### PR TITLE
Add components_add override to open up all storage components

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -1,7 +1,8 @@
 {
     "target_overrides": {
         "*": {
-            "platform.stdio-convert-newlines": true
+            "platform.stdio-convert-newlines": true,
+            "target.components_add": ["SD", "SPIF", "DATAFLASH", "FLASHIAP"]
         }
     }
 }


### PR DESCRIPTION
cc @yossi2le, @deepikabhavnani, @ARMmbed/mbed-os-storage 
related https://github.com/ARMmbed/mbed-os-example-blockdevice/pull/14