### PR TITLE
 Add constructors for multiple common block device types including QSPIF

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -20,14 +20,48 @@
 // Block devices
 #if COMPONENT_SPIF
 #include "SPIFBlockDevice.h"
+// Physical block device, can be any device that supports the BlockDevice API
+SPIFBlockDevice bd(
+        MBED_CONF_SPIF_DRIVER_SPI_MOSI,
+        MBED_CONF_SPIF_DRIVER_SPI_MISO,
+        MBED_CONF_SPIF_DRIVER_SPI_CLK,
+        MBED_CONF_SPIF_DRIVER_SPI_CS);
+
 #endif
 
 #if COMPONENT_DATAFLASH
 #include "DataFlashBlockDevice.h"
+// Physical block device, can be any device that supports the BlockDevice API
+DataFlashBlockDevice bd(
+        MBED_CONF_DATAFLASH_SPI_MOSI,
+        MBED_CONF_DATAFLASH_SPI_MISO,
+        MBED_CONF_DATAFLASH_SPI_CLK,
+        MBED_CONF_DATAFLASH_SPI_CS);
+
 #endif 
 
 #if COMPONENT_SD
 #include "SDBlockDevice.h"
+// Physical block device, can be any device that supports the BlockDevice API
+SDBlockDevice bd(
+        MBED_CONF_SD_SPI_MOSI,
+        MBED_CONF_SD_SPI_MISO,
+        MBED_CONF_SD_SPI_CLK,
+        MBED_CONF_SD_SPI_CS);
+#endif 
+
+#if COMPONENT_QSPIF
+#include "QSPIFBlockDevice.h"
+// Physical block device, can be any device that supports the BlockDevice API
+QSPIFBlockDevice bd(
+        MBED_CONF_QSPIF_QSPI_IO0,
+        MBED_CONF_QSPIF_QSPI_IO1,
+        MBED_CONF_QSPIF_QSPI_IO2,
+        MBED_CONF_QSPIF_QSPI_IO3,
+        MBED_CONF_QSPIF_QSPI_SCK,
+        MBED_CONF_QSPIF_QSPI_CSN,
+        QSPIF_POLARITY_MODE_0,
+        MBED_CONF_QSPIF_QSPI_FREQ);
 #endif 
 
 #include "HeapBlockDevice.h"
@@ -36,13 +70,6 @@
 #include "LittleFileSystem.h"
 #include "FATFileSystem.h"
 
-
-// Physical block device, can be any device that supports the BlockDevice API
-SPIFBlockDevice bd(
-        MBED_CONF_SPIF_DRIVER_SPI_MOSI,
-        MBED_CONF_SPIF_DRIVER_SPI_MISO,
-        MBED_CONF_SPIF_DRIVER_SPI_CLK,
-        MBED_CONF_SPIF_DRIVER_SPI_CS);
 
 // File system declaration
 LittleFileSystem fs("fs");
@@ -231,4 +258,3 @@ int main() {
         
     printf("Mbed OS filesystem example done!\n");
 }
-

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#610e35ddc6d59f153173c1e7b2748cf96d6c9bcd
+https://github.com/ARMmbed/mbed-os/#103c9cb509c706ac972f0e8767141a5bf0270651


### PR DESCRIPTION
Can we get block device constructors for multiple devices in this example?   I had to make these changes while testing this example with a Quad SPI Flash.  It worked!   I thought it would be nice to just have the constructors for all the common block device types.  

I did a full test  with DISCO_L475VG_IOT01A.  

Compiled successfully for K64F (SD), and USI_WM_BN_BM_22 (SPIF)
