### PR TITLE
Use BlockDevice get_default_instance method to determine block device

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,2 @@
-https://github.com/ARMmbed/mbed-os/#610e35ddc6d59f153173c1e7b2748cf96d6c9bcd
+https://github.com/ARMmbed/mbed-os/#2fd0c5cfbd83fce62da6308f9d64c0ab64e1f0d6
+


### PR DESCRIPTION
Use ` get_default_instance` method to determine active block device, instead of component specific ones, which may be inappropriate or non existing for the current board.