### PR TITLE
Updating mbed-os to mbed-os-5.12.2

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,2 +1,2 @@
-https://github.com/ARMmbed/mbed-os/#0063e5de32fc575f061244c96ac60c41c07bd2e6
+https://github.com/ARMmbed/mbed-os/#cfa7938a4dd6d1a4c501945b9c26ca68f70e284e
 


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.12.2 . 