### PR TITLE
Turn on platform.callback-nontrivial

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -1,7 +1,8 @@
 {
     "target_overrides": {
         "*": {
-            "platform.stdio-convert-newlines": true
+            "platform.stdio-convert-newlines": true,
+            "platform.callback-nontrivial": true
         }
     }
 }


### PR DESCRIPTION
This example uses `Event` with `Callback` which means `platform.callback-nontrivial` needs to be `true`. Turn this on in the app, as we're planning to make `false` the default in Mbed OS. (https://github.com/ARMmbed/mbed-os/pull/12761)

This option is new on master (https://github.com/ARMmbed/mbed-os/pull/12036), so this change would stop the example compiling on 5.15 or earlier.