### PR TITLE
Don't require platform.callback-nontrivial

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -16,6 +16,7 @@
 #include "mbed.h"
 #include <stdio.h>
 #include <errno.h>
+#include <functional>
 
 #include "BlockDevice.h"
 
@@ -68,6 +69,7 @@ void erase() {
     }
 }
 
+static auto erase_event = mbed_event_queue()->make_user_allocated_event(erase);
 
 // Entry point for the example
 int main() {
@@ -75,7 +77,7 @@ int main() {
 
     // Setup the erase event on button press, use the event queue
     // to avoid running in interrupt context
-    irq.fall(mbed_event_queue()->event(erase));
+    irq.fall(std::ref(erase_event));
 
     // Try to mount the filesystem
     printf("Mounting the filesystem... ");

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,2 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#51d55508e8400b60af467005646c4e2164738d48
-
+https://github.com/ARMmbed/mbed-os/#b6370b4c37f3d4665ed1cdcb1afea85396bba1b3


### PR DESCRIPTION
Don't use an `Event` with `Callback` - it's non-trivial, so needs the "full" form of `Callback`. `Callback` is being switched to not support non-trivial functors by default to save ROM.

Use a `reference_wrapper` to a `UserAllocatedEvent` instead, which works fine with the trivial-only `Callback`.

A `reference_wrapper` is small enough to fit in a `Callback`, and is trivially-copyable, so works to decouple the event lifetime from the callback. Having decoupled it, the event has program lifetime, so may as well be `UserAllocatedEvent` for simplicity.

(`UserAllocatedEvent` could be trivial, but is too big to be placed in a `Callback` directly in any case).