### PR TITLE
update 5.15 branch with force format

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -21,7 +21,7 @@
 
 // Maximum number of elements in buffer
 #define BUFFER_MAX_LEN 10
-
+#define FORCE_REFORMAT true
 // This will take the system's default block device
 BlockDevice *bd = BlockDevice::get_default_instance();
 
@@ -82,10 +82,9 @@ int main() {
     fflush(stdout);
     int err = fs.mount(bd);
     printf("%s\n", (err ? "Fail :(" : "OK"));
-    if (err) {
+    if (err || FORCE_REFORMAT) {
         // Reformat if we can't mount the filesystem
-        // this should only happen on the first boot
-        printf("No filesystem found, formatting... ");
+        printf("formatting... ");
         fflush(stdout);
         err = fs.reformat(bd);
         printf("%s\n", (err ? "Fail :(" : "OK"));

--- a/tests/filesystem.log
+++ b/tests/filesystem.log
@@ -1,6 +1,5 @@
 --- Mbed OS filesystem example ---
 Mounting the filesystem... OK
-Opening "\/fs\/numbers.txt"... OK
 Incrementing numbers \(10\/10\)... OK
 Closing "\/fs\/numbers.txt"... OK
 Opening the root directory... OK


### PR DESCRIPTION
This example not always formating the blockdevice by default.
It only performing format when mounting is failing.

In our daily test, the blockdeivce not always is a ready state. even mounting is not report any error. 
it can generate a crashing later. if the blockdevice is corrupted 
So in the PR adding the force format macro, so always reformat the chosen blockdeivice by default.

This one is for 5.15 branch testing. I will port this for the master as well 